### PR TITLE
#163388243 Configure Authors Haven to use PostgreSQL as DB Engine

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+import dj_database_url
+from decouple import config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -80,10 +82,7 @@ WSGI_APPLICATION = 'authors.wsgi.application'
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    'default': dj_database_url.config(default=config("DATABASE_URL"))
 }
 
 # Password validation
@@ -137,5 +136,5 @@ REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'authors.apps.core.exceptions.core_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error',
 
-    
+
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
 asn1crypto==0.24.0
 cffi==1.11.5
 cryptography==2.5
+dj-database-url==0.5.0
 Django==2.1.5
 django-cors-headers==2.4.0
 django-extensions==2.1.4
 djangorestframework==3.9.1
-djangorestframework-jwt==1.11.0
 jwt==0.5.4
+psycopg2==2.7.7
+psycopg2-binary==2.7.7
 pycparser==2.19
-PyJWT==1.7.1
+python-decouple==3.1
 pytz==2018.9
 six==1.12.0


### PR DESCRIPTION
**What does this PR do?**

SetsUp Postgresql Database as the default database for the application

**Description of Task to be completed?**

Download and configure postgresql database to be the default database for the application

**How should this be manually tested?**

Clone the repo and cd into it

. checkout to the branch git checkout Ch-set-up-database-163388243

. pip install -r requirements.txt

Install postgresql database on your PC.

- create database 'authorshaven'

- create user 'birdbox'

- grant all privileges to database 'authorshaven' to user 'birdbox'

- set the user password as a OS enviroment variable on the terminal. `export DBpass="your password" `

- `python3 manage.py makemigrations` then `python3 manage.py migrate` to test the database 


**Any background context you want to provide?**

None

**What are the relevant pivotal tracker stories?**

[#163388238](https://www.pivotaltracker.com/story/show/163388243)

**Screenshots (if appropriate)**

None