### PR TITLE
#163987735 user should not login without verifying email

### DIFF
--- a/authors/apps/articles/tests/test_pagination.py
+++ b/authors/apps/articles/tests/test_pagination.py
@@ -3,6 +3,7 @@ from .base_test import TestBaseCase
 
 class PaginationTestCase(TestBaseCase):
     def create_multiple_articles(self):
+        self.authenticate_user(self.test_user)
         for i in range(21):
             self.create_article()
 

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -85,6 +85,10 @@ class LoginSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 'A user with this email and password was not found.'
             )
+        if not user.is_verified:
+            raise serializers.ValidationError(
+                'Please verify your email first'
+            )
 
         # Django provides a flag on our `User` model called `is_active`. The
         # purpose of this flag to tell us whether the user has been banned

--- a/authors/apps/authentication/tests/base_test.py
+++ b/authors/apps/authentication/tests/base_test.py
@@ -4,6 +4,7 @@ from rest_framework.test import APITestCase, APIClient
 from django.core import mail
 from bs4 import BeautifulSoup
 import re
+from authors.apps.authentication.models import User
 
 
 class TestConfiguration(APITestCase):
@@ -168,6 +169,9 @@ class TestConfiguration(APITestCase):
 
     def get_user_token(self):
         self.register_user(data=self.user)
+        user = User.objects.get(email=self.user['email'])
+        user.is_verified = True
+        user.save()
         response = self.user_login_req(data=self.user_login)
         return response.data['token']
 

--- a/authors/apps/authentication/tests/test_jwt.py
+++ b/authors/apps/authentication/tests/test_jwt.py
@@ -18,8 +18,11 @@ class JwtTestCase(TestConfiguration):
         """Test token generation at login."""
 
         self.register_user(data=self.user)
+        user = User.objects.get(email=self.user['email'])
+        user.is_verified = True
+        user.save()
         response = self.user_login_req(data=self.user_login)
-        self.assertEqual(response.data['email'], "graceunah@gmail.com")
+        self.assertEqual(response.data['email'], "graceunah@gmail.com")  # noqa
         self.assertIn('token', response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 

--- a/authors/apps/authentication/tests/test_login.py
+++ b/authors/apps/authentication/tests/test_login.py
@@ -5,12 +5,13 @@ from authors.apps.authentication.tests.base_test import TestConfiguration
 
 class TestLogin(TestConfiguration):
 
-    def test_successful_login(self):
+    def test_unsuccessful_login(self):
         """test if login is successful """
         self.register_user(data=self.user)
         response = self.user_login_req(data=self.user_login)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['email'], "graceunah@gmail.com")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['errors']['error'][0],
+                         "Please verify your email first")
 
     def test_login_email_does_not_exist(self):
         """ test login with non existing email """

--- a/authors/apps/comments/tests/base_test.py
+++ b/authors/apps/comments/tests/base_test.py
@@ -71,19 +71,20 @@ class BaseTest(APITestCase):
             format='json'
         )
 
-    def authenticate_user(self, user):
+    def authenticate_user(self, data):
         """
         Register and login an authorized user
         """
-        self.client.post(
-            self.register_url,
-            user,
-            format='json'
-        )
         response = self.client.post(
-            self.login_url,
-            user,
-            format='json'
+            self.register_url, data, format='json')
+        token = response.data['user_info']['token']
+        self.verify_user_registration(token)
+        response = self.client.post(
+            self.login_url, data, format='json'
         )
         token = response.data['token']
         self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+
+    def verify_user_registration(self, token):
+        verify_url = reverse('authentication:verify_email', args=[token])
+        self.client.get(verify_url)


### PR DESCRIPTION

#### What does this PR do?
Have user cannot login without verifying email
#### Description of Task to be completed?
- add validation in the Loginserializer
- fix login tests
#### How should this be manually tested?
* clone the repo and `cd` into it.
* checkout to the branch
  `git checkout bg-fix-user-login-163987735`

* Run server
  `python manage.py runserver`

* test on postman using

 the url ` http://127.0.0.1:8000/api/users` to register a user by inputing on the payload:
   ```
             {
		"username":"yourusername",
		"email": "youremail",
		"password":"yourpassword"
             }
```
- Login using the registered credentials after verifying email using the url ` http://127.0.0.1:8000/api/users`
- Login should be successful if email has been verified otherwise a message should appear you verify the email first.
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#163987735](https://www.pivotaltracker.com/n/projects/2240063)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42655718/52838258-0fb9ab80-3103-11e9-9fdb-9c3e33ebd6ee.png)

#### Questions:
