### PR TITLE
#163388246 Document the API with Django Rest Swagger

### DIFF
--- a/authors/settings.py
+++ b/authors/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 
     'social_django',
     'cloudinary',
+    'rest_framework_swagger'
 ]
 
 MIDDLEWARE = [
@@ -213,4 +214,17 @@ CLOUDINARY = {
   'api_key': config('CLOUDINARY_KEY'),
   'api_secret': config('CLOUDINARY_SECRET'),
   'secure': True
+}
+
+SWAGGER_SETTINGS = {
+  'SHOW_REQUEST_HEADERS': True,
+  'USE_SESSION_AUTH': False,
+  'DOC_EXPANSION': 'list',
+  'SECURITY_DEFINITIONS': {
+      'api_key': {
+          'type': 'apiKey',
+          'in': 'header',
+          'name': 'Authorization'
+      }
+  }
 }

--- a/authors/swagger.py
+++ b/authors/swagger.py
@@ -1,0 +1,428 @@
+from rest_framework.decorators import renderer_classes, api_view
+from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer
+import coreapi
+from rest_framework import response
+
+
+@api_view()
+@renderer_classes([SwaggerUIRenderer, OpenAPIRenderer])
+def schema_view(request):
+    schema = coreapi.Document(
+        title='Authors Haven API',
+        url='https://ah-bird-box-staging.herokuapp.com',
+        content={
+            'Authentication': {
+                'create_user': coreapi.Link(
+                    url='/api/users/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='username',
+                            required=True,
+                            location='form',
+                            description='A unique word that will identify the user.' # noqa
+                        ),
+                        coreapi.Field(
+                            name='email',
+                            required=True,
+                            location='form',
+                            description='A user\'s valid e-mail address'
+                        ),
+                        coreapi.Field(
+                            name='password',
+                            required=True,
+                            location='form',
+                            description='A strong password for the user'
+                        )
+                    ],
+                    description='Create a new Account.'
+                ),
+                'login_user': coreapi.Link(
+                    url='/api/users/login/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='email',
+                            required=True,
+                            location='form',
+                            description='A user\'s e-mail address'
+                        ),
+                        coreapi.Field(
+                            name='password',
+                            required=True,
+                            location='form',
+                            description='The password of User.'
+                        )
+                    ],
+                    description='Login a User.'
+                ),
+                'social auth': coreapi.Link(
+                    url='/api/social/login/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='provider',
+                            required=True,
+                            location='form',
+                            description='The name of the provider.'
+                        ),
+                        coreapi.Field(
+                            name='access_token',
+                            required=True,
+                            location='form',
+                            description='The acess token of the User.'
+                        ),
+                        coreapi.Field(
+                            name='access_token_secret',
+                            required=False,
+                            location='form',
+                            description='The access token secret of the User (twitter).' # noqa
+                        )
+                    ],
+                    description='Login via social sites'
+                ),
+                'password_reset': coreapi.Link(
+                    url='/api/users/password_reset/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='email',
+                            required=True,
+                            location='form',
+                            description='The email of the User.'
+                        ),
+                    ],
+                    description='Request for a password reset.'
+                ),
+                'password_update': coreapi.Link(
+                    url='/api/users/password_update/{token}',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='password',
+                            required=True,
+                            location='form',
+                            description='The password of the User.'
+                        ),
+                        coreapi.Field(
+                            name='confirm_password',
+                            required=True,
+                            location='form',
+                            description='The password of User.'
+                        )
+                    ],
+                    description='Update password of a User.'
+                ),
+            },
+            'Profile': {
+                'get_user_profile': coreapi.Link(
+                    url='/api/users/{username}/',
+                    action='GET',
+                    fields=[
+                        coreapi.Field(
+                            name='username',
+                            required=True,
+                            location='path',
+                            description='Username of the User.'
+                        )
+
+                    ],
+                    description='Get profile of a single user.'
+
+                ),
+                'update_user_profile': coreapi.Link(
+                    url='/api/users/{username}/',
+                    action='PUT',
+                    fields=[
+                        coreapi.Field(
+                            name='username',
+                            required=True,
+                            location='path',
+                            description='Username of the User.'
+                        ),
+                        coreapi.Field(
+                            name='bio',
+                            required=False,
+                            location='form',
+                            description='The bio of the User.'
+                        ),
+                        coreapi.Field(
+                            name='company',
+                            required=False,
+                            location='form',
+                            description='The company of User.'
+                        ),
+                        coreapi.Field(
+                            name='website',
+                            required=False,
+                            location='form',
+                            description='The website of the user.'
+                        ),
+                        coreapi.Field(
+                            name='phone',
+                            required=False,
+                            location='form',
+                            description='The phone number of the User.'
+                        ),
+                        coreapi.Field(
+                            name='image_url',
+                            required=False,
+                            location='form',
+                            description='The image of User.'
+                        )
+                    ],
+                    description='Update user profile'
+                ),
+                'get all profiles': coreapi.Link(
+                    url='/api/profiles/',
+                    action='GET',
+                    description='Get all profiles'
+                ),
+            },
+            'Articles': {
+                'create_article': coreapi.Link(
+                    url='/api/articles/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='title',
+                            required=True,
+                            location='form',
+                            description='The title of the article.'
+                        ),
+                        coreapi.Field(
+                            name='description',
+                            required=True,
+                            location='form',
+                            description='The article description.'
+                        ),
+                        coreapi.Field(
+                            name='body',
+                            required=True,
+                            location='form',
+                            description='The article body'
+                        ),
+                        coreapi.Field(
+                            name='image_url',
+                            required=False,
+                            location='form',
+                            description='The article body'
+                        )
+                    ],
+                    description='Create Article'
+                ),
+                'get_articles': coreapi.Link(
+                    url='/api/articles/',
+                    action='GET',
+                    description='Display all the articles.',
+                ),
+                'get_single_article': coreapi.Link(
+                    url='/api/articles/{slug}/',
+                    action='GET',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        )],
+                    description='Display a single article',
+                ),
+                'update_single_article': coreapi.Link(
+                    url='/api/articles/{slug}/',
+                    action='PUT',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        ),
+                        coreapi.Field(
+                            name='title',
+                            location='form',
+                            description='New title'
+                        ),
+                        coreapi.Field(
+                            name='description',
+                            location='form',
+                            description='New description'
+                        ),
+                        coreapi.Field(
+                            name='image_url',
+                            location='form',
+                            description='New image url'
+                        ),
+                    ],
+                    description='Update an article',
+                ),
+                'delete_single_article': coreapi.Link(
+                    url='/api/articles/{slug}/',
+                    action='DELETE',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        )
+                    ],
+                    description='Delete an article',
+                ),
+                'comments': coreapi.Link(
+                    url='/api/articles/{slug}/comments/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        ),
+                        coreapi.Field(
+                            name='body',
+                            required=True,
+                            location='form',
+                            description='Body of the comemnt'
+                        ),
+                    ],
+                    description='Comment on an article',
+                ),
+                'get all comments': coreapi.Link(
+                    url='/api/articles/{slug}/comments/',
+                    action='GET',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        ),
+                    ],
+                    description='Get all coments on an article',
+                ),
+                'get a specific comment': coreapi.Link(
+                    url='/api/articles/{slug}/comments/{id}/',
+                    action='GET',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        ),
+                        coreapi.Field(
+                            name='id',
+                            required=True,
+                            location='path',
+                            description='The id of the comment.'
+                        ),
+                    ],
+                    description='Get a specific comment',
+                ),
+                'update_single_comment': coreapi.Link(
+                    url='/api/articles/{slug}/comments/{id}/',
+                    action='PUT',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        ),
+                        coreapi.Field(
+                            name='id',
+                            required=True,
+                            location='path',
+                            description='The id of the comment.'
+                        ),
+
+                        coreapi.Field(
+                            name='body',
+                            location='form',
+                            description='New body on the comment'
+                        ),
+                    ],
+                    description='Update a comment',
+                ),
+                'delete_single_comment': coreapi.Link(
+                    url='/api/articles/{slug}/comments/{id}/',
+                    action='DELETE',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        ),
+                        coreapi.Field(
+                            name='id',
+                            required=True,
+                            location='path',
+                            description='The id of the comment.'
+                        ),
+                    ],
+                    description='Delete a comment',
+                ),
+                'thread': coreapi.Link(
+                    url='/api/articles/{slug}/comments/{id}/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='slug of the article'
+                        ),
+                        coreapi.Field(
+                            name='id',
+                            required=True,
+                            location='path',
+                            description='Id of the comment'
+                        ),
+                        coreapi.Field(
+                            name='body',
+                            required=True,
+                            location='form',
+                            description='Body of a single thread'
+                        ),
+                    ],
+                    description='Comment on a comment',
+                ),
+
+                'rate_an_article': coreapi.Link(
+                    url='/api/articles/{slug}/ratings/',
+                    action='POST',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='slug of the article'
+                        ),
+                        coreapi.Field(
+                            name='stars',
+                            required=True,
+                            location='form',
+                            description='Rating of the article'
+                        ),
+                    ],
+                    description='Rate an article',
+                ),
+                'get_rating_for an_article': coreapi.Link(
+                    url='/api/articles/{slug}/ratings/',
+                    action='GET',
+                    fields=[
+                        coreapi.Field(
+                            name='slug',
+                            required=True,
+                            location='path',
+                            description='The slug of the article.'
+                        )],
+                    description='Display rating of an article',
+                ),
+            }
+        }
+    )
+
+    return response.Response(schema)

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 from django.urls import include, path
 from django.contrib import admin
 
+from .swagger import schema_view
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include(
@@ -25,4 +27,5 @@ urlpatterns = [
         'authors.apps.articles.urls', namespace='articles')),
     path('api/', include(
         'authors.apps.comments.urls', namespace='comments')),
+    path('api/docs/', schema_view),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ cffi==1.11.5
 chardet==3.0.4
 Click==7.0
 cloudinary==1.15.0
+coreapi==2.3.3
+coreschema==0.0.4
 coverage==4.5.2
 coveralls==1.5.1
 cryptography==2.5
@@ -20,6 +22,7 @@ django-cors-headers==2.4.0
 django-cors-middleware==1.3.1
 django-extensions==2.1.4
 django-heroku==0.3.1
+django-rest-swagger==2.2.0
 djangorestframework==3.9.1
 docopt==0.6.2
 entrypoints==0.3
@@ -29,11 +32,15 @@ gunicorn==19.9.0
 idna==2.8
 image==1.5.27
 isort==4.3.4
+itypes==1.1.0
+Jinja2==2.10
 lazy-object-proxy==1.3.1
+MarkupSafe==1.1.0
 mccabe==0.6.1
 mock==2.0.0
 more-itertools==5.0.0
 oauthlib==3.0.1
+openapi-codec==1.3.2
 pbr==5.1.2
 Pillow==5.4.1
 pluggy==0.8.1
@@ -53,6 +60,7 @@ python3-openid==3.1.0
 pytz==2018.9
 requests==2.21.0
 requests-oauthlib==1.2.0
+simplejson==3.16.0
 six==1.12.0
 social-auth-app-django==3.1.0
 social-auth-core==3.0.0
@@ -60,6 +68,7 @@ soupsieve==1.7.3
 sparkpost==1.3.6
 toml==0.10.0
 tox==3.7.0
+uritemplate==3.0.0
 urllib3==1.24.1
 virtualenv==16.3.0
 whitenoise==4.1.2


### PR DESCRIPTION
#### What does this PR do?
Documents the API's endpoints with django-rest swagger

#### Description of Task to be completed?
- Setup swagger in the application
- Add all existing endpoints to the documentation
- Refactor code

#### How should this be manually tested?
On a browser, follow the link `{{BASE_URL}}/api/docs/`
N/B: Base url can be `http://127.0.0.1:8000` for the localhost or `ah-bird-box-staging.herokuapp.com` for staging
#### Any background context you want to provide?
- consider HTTP and HTTPS options. HTTP is used when the BASE_URL is localhost

#### What are the relevant pivotal tracker stories?
[#163388246](https://www.pivotaltracker.com/story/show/163388246)

#### Screenshots (if appropriate)
**_Endpoints documented_**
![image](https://user-images.githubusercontent.com/29451552/52936137-5c53ef80-336c-11e9-8a35-50dd78f1a4ab.png)

**_Test post data through the documentation_**
![image](https://user-images.githubusercontent.com/29451552/52936162-71308300-336c-11e9-9fd9-49f6e092ed1f.png)