### PR TITLE
#164043307 Fix response for non-existent comment

### DIFF
--- a/authors/apps/comments/tests/test_comments.py
+++ b/authors/apps/comments/tests/test_comments.py
@@ -90,9 +90,9 @@ class TestComments(BaseTest):
         url = self.comment_url("my-data") + comment_id + '/'
         self.client.delete(url)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(response.data['comment']
-                         ['error'], "Sorry, comment was not found")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('comment', response.data)
+        self.assertIn('commentsCount', response.data)
 
     def test_user_can_update_comment(self):
         """

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -27,19 +27,10 @@ class CommentsAPIView(APIView):
                         "error": "Sorry, article was not found"
                     }
                 },
-                status=status.HTTP_204_NO_CONTENT
+                status=status.HTTP_200_OK
             )
 
         queryset = Comments.objects.filter(article=article.id)
-        if not queryset:
-            return Response(
-                {
-                    "comment": {
-                        "error": "Sorry, You do not have any comments yet"
-                    }
-                },
-                status=status.HTTP_204_NO_CONTENT
-            )
         serializer = self.serializer_class(data=queryset, many=True)
         serializer.is_valid()
         return Response({
@@ -94,21 +85,13 @@ class CommentDetailsAPIView(RetrieveUpdateDestroyAPIView, ListCreateAPIView):
                         "error": "Sorry, article was not found"
                     }
                 },
-                status=status.HTTP_204_NO_CONTENT
+                status=status.HTTP_200_OK
             )
         queryset = Comments.objects.filter(id=id, article=article.id)
-        if not queryset:
-            return Response(
-                {
-                    "comment": {
-                        "error": "Sorry, comment was not found"
-                    }
-                },
-                status=status.HTTP_204_NO_CONTENT
-            )
         serializer = self.serializer_class(queryset, many=True)
         return Response({
-            "comment": serializer.data[0]
+            "comment": serializer.data,
+            "commentsCount": queryset.count()
         },
             status=status.HTTP_200_OK
         )


### PR DESCRIPTION
#### What does this PR do?
It fixes the response when retrieving a non-existent comment,
#### Description of Task to be completed?
Use HTTP_200_OK status code to enable response of an empty list and zero comment count to be displayed.
#### How should this be manually tested?
1. Checkout to the branch ```git checkout bg-fix-no-comments-164043307```
2. Run the application with ```python manage.py runserver```
3. Go to postman and make the following requests:

Method | Endpoint | Functionality
--- | --- | ---
POST | `{{base-url}}/articles/<article-slug>/comments/` | Post a new comment
POST | `{{base-url}}/articles/<article-slug>/comments/<comment_id>/` | Post a new reply to a comment
GET | `{{base-url}}/articles/<article-slug>/comments/` | Retrieve all comments and replies
GET | `{{base-url}}/articles/<article-slug>/comments/<comment_id>` | Retrieve a specific comment or reply
DELETE | `{{base-url}}/articles/<article-slug>/comments/<comment_id>/` | Delete a specific comment or reply

After deleting a comment, make a request to get that comment
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#164043307](https://www.pivotaltracker.com/n/projects/2240063)
#### Screenshots (if appropriate)
**Response when a comment is deleted**
![image](https://user-images.githubusercontent.com/38856515/52944981-c4f99700-3381-11e9-83b9-b2d54cc247ab.png)
#### Questions:
None