### PR TITLE
#164329231 Fixes update comment response

### DIFF
--- a/authors/apps/comments/tests/test_comments.py
+++ b/authors/apps/comments/tests/test_comments.py
@@ -111,9 +111,9 @@ class TestComments(BaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
-            response.data['comment']['message'],
-            "Comment was successfully updated"
+            response.data['message'], "Comment was successfully updated"
         )
+        self.assertIn('comment', response.data)
 
     def test_unauthorized_update_comment(self):
         """

--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -208,16 +208,16 @@ class CommentDetailsAPIView(RetrieveUpdateDestroyAPIView, ListCreateAPIView):
             )
 
         comment_data = request.data
-        comment.body = comment_data['body']
-        comment.save(update_fields=['body'])
-        return Response(
-            {
-                "comment": {
-                    "message": "Comment was successfully updated"
-                }
+        serializer = self.serializer_class(
+            comment, data=comment_data, partial=True)
+        if serializer.is_valid():
+            serializer.save()
+            return Response({
+                "message": "Comment was successfully updated",
+                "comment": serializer.data
             },
-            status=status.HTTP_200_OK
-        )
+                status=status.HTTP_200_OK
+            )
 
 
 class CommentsHistoryAPIView(ListCreateAPIView):


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the response of the update comment endpoint
#### Description of Task to be completed?
Add the comment body as part of the update comment response
#### How should this be manually tested?
1. Checkout to the branch ```bg-comments-bug-164329231```
2. Run the server ```python manage.py runserver```
3. Go to Postman and make the following request:

Method | Endpoint | Functionality
--- | --- | ---
POST | `{{base-url}}/articles/` | Post article
POST | `{{base-url}}/articles/<article_slug>/comments/` | Post comment
PUT | `{{base-url}}/articles/<article_slug>/comments/<comment_id>` | Update comment
GET | `{{base-url}}/articles/<article_slug>/comments/<comment_id>/history/` | Get edit history
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
[#164329231](https://www.pivotaltracker.com/n/projects/2240063)
#### Screenshots (if appropriate)

**Post article**
![image](https://user-images.githubusercontent.com/38856515/53642638-4cc58800-3c43-11e9-916a-29fd6bf5ae6a.png)

**Post comment to the article above**
![image](https://user-images.githubusercontent.com/38856515/53642738-74b4eb80-3c43-11e9-81fd-c5b07ef0e816.png)

**Update the comment above**
![image](https://user-images.githubusercontent.com/38856515/53642790-9a41f500-3c43-11e9-8a78-03b1c9b97131.png)

**Get edit history for that comment**
![image](https://user-images.githubusercontent.com/38856515/53642845-bb0a4a80-3c43-11e9-9bc2-e8d54e5a063b.png)

#### Questions:
None