### PR TITLE
Retrieve password reset link from environment

### DIFF
--- a/authors/apps/authentication/helper_functions/send_email.py
+++ b/authors/apps/authentication/helper_functions/send_email.py
@@ -1,4 +1,3 @@
-from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
 from django.utils.html import strip_tags
@@ -26,9 +25,8 @@ def send_email(recipient, token, request, message, subject):
 
 def send_reset_password_email(recipient, token, request):
     subject = "Password Reset Request"
-    host_url = get_current_site(request)
-    link = "http://" + host_url.domain + \
-        '/api/users/update_password/{}'.format(token)
+    password_reset_url = config("VERIFICATION_URL")
+    link = "{}/update_password/{}".format(password_reset_url, token)
     message = create_email_message(link, subject, 'email_template.html')
     send_email(recipient, token, request, message, subject)
     result = {

--- a/authors/apps/authentication/tests/base_test.py
+++ b/authors/apps/authentication/tests/base_test.py
@@ -53,7 +53,7 @@ class TestConfiguration(APITestCase):
         }
 
         self.oauth2_data = {
-            "provider": "facebook",
+            "provider": "google-oauth2",
             "access_token": self.oauth2_token
         }
 


### PR DESCRIPTION
#### What does this PR do?
This PR resolves the send password reset link functionality
#### Description of Task to be completed?
Export password reset link from the environment
#### How should this be manually tested?
Reset password for the user with the environment value for key VERIFICATION_URL set to either localhost or Heroku 
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A